### PR TITLE
Solving bug for MANIHOT and CROPSIM models

### DIFF
--- a/Plant/CSCER_CSCRP_CSCAS/CSCAS.for
+++ b/Plant/CSCER_CSCRP_CSCAS/CSCAS.for
@@ -2530,9 +2530,16 @@
 
         ! CHP 5/4/09 - for DSSAT runs, always set PLYEAR = YEAR
         ! CHP 09/28/09 - account for planting date >> simulation date.
-        IF (FILEIOT(1:2).EQ.'DS' .AND. YEAR > PLYEAR) THEN
-          PLYEAR = YEAR
-          PLYEARTMP = YEAR
+        !LPM 07/17/20 - account for simulation date when is a year before planting date
+        !Avoid wrong value of yeardoyharf
+        IF (FILEIOT(1:2) == 'DS' .AND. YEAR > PLYEAR) THEN
+            IF (YEAR < PLYEARREAD) THEN
+                PLYEAR = PLYEARREAD
+                PLYEARTMP = PLYEARREAD
+            ELSE
+                PLYEAR = YEAR
+                PLYEARTMP = YEAR
+            ENDIF
         ENDIF
 
         ! Check final harvest date for seasonal runs        

--- a/Plant/CSCER_CSCRP_CSCAS/CSCER.for
+++ b/Plant/CSCER_CSCRP_CSCAS/CSCER.for
@@ -1800,9 +1800,14 @@
           ! CHP 5/4/09 - for DSSAT runs, always set PLYEAR = YEAR
           ! 09/28/2009 CHP need to account for planting date >> simulation date.
           !  IF (FILEIOT(1:2).EQ.'DS') THEN
-        
-          IF (FILEIOT(1:2).EQ.'DS' .AND. YEAR > PLYEAR) THEN
-            PLYEAR = YEAR
+          !LPM 07/17/20 - account for simulation date when is a year before planting date
+          !Avoid wrong value of yeardoyharf
+          IF (FILEIOT(1:2) == 'DS' .AND. YEAR > PLYEAR) THEN
+              IF (YEAR < PLYEARREAD) THEN
+                  PLYEAR = PLYEARREAD
+              ELSE
+                  PLYEAR = YEAR
+              ENDIF
           ENDIF
 
           IF (PLDAY.GE.DOY) THEN

--- a/Plant/CSCER_CSCRP_CSCAS/CSCRP.for
+++ b/Plant/CSCER_CSCRP_CSCAS/CSCRP.for
@@ -3011,9 +3011,16 @@
 
         ! CHP 5/4/09 - for DSSAT runs, always set PLYEAR = YEAR
         ! CHP 09/28/2009 account for planting date >> simulation date.
-        IF (FILEIOT(1:2).EQ.'DS' .AND. YEAR > PLYEAR) THEN
-          PLYEAR = YEAR
-          PLYEARTMP = YEAR
+        !LPM 07/17/20 - account for simulation date when is a year before planting date
+        !Avoid wrong value of yeardoyharf
+        IF (FILEIOT(1:2) == 'DS' .AND. YEAR > PLYEAR) THEN
+            IF (YEAR < PLYEARREAD) THEN
+                PLYEAR = PLYEARREAD
+                PLYEARTMP = PLYEARREAD
+            ELSE
+                PLYEAR = YEAR
+                PLYEARTMP = YEAR
+            ENDIF
         ENDIF
 
         IF (IDATE1.GT.0.AND.CFLPDATE.EQ.'I') THEN

--- a/Plant/CSYCA-Cassava/YCA_SeasInit_PlHarvDat.f90
+++ b/Plant/CSYCA-Cassava/YCA_SeasInit_PlHarvDat.f90
@@ -23,9 +23,16 @@
       
       ! CHP 5/4/09 - for DSSAT runs, always set PLYEAR = YEAR
       ! CHP 09/28/09 - account for planting date >> simulation date.
+      !LPM 07/17/20 - account for simulation date when is a year before planting date
+      !Avoid wrong value of yeardoyharf
       IF (FILEIOT(1:2) == 'DS' .AND. YEAR > PLYEAR) THEN
-          PLYEAR = YEAR
-          PLYEARTMP = YEAR
+          IF (YEAR < PLYEARREAD) THEN
+              PLYEAR = PLYEARREAD
+              PLYEARTMP = PLYEARREAD
+          ELSE
+              PLYEAR = YEAR
+              PLYEARTMP = YEAR
+          ENDIF
       ENDIF
       
       ! Check final harvest date for seasonal runs        


### PR DESCRIPTION
Issue solved: cassava model was not running when start of simulation is during the year before planting year and there was a file T. If the file T was removed, the model could run without any issues.