### PR TITLE
Fixed Y2K/Y4K weather file unit issue

### DIFF
--- a/InputModule/MAKEFILEW.f90
+++ b/InputModule/MAKEFILEW.f90
@@ -26,7 +26,7 @@
       CHARACTER*6   ERRKEY,SECTION
       CHARACTER*5   FINDH
       CHARACTER*8   WSTA,FILEW4,FILEX
-      CHARACTER*12  FILEW,NAMEF
+      CHARACTER*12  FILEW,NAMEF, LastFileW
       CHARACTER*78  MSG(4)
       CHARACTER*80  PATHWT,PATHEX,CHARTEST
       CHARACTER*92  FILEWW,FILETMP
@@ -43,6 +43,7 @@
       INTEGER       LNPLT,TLNPLT
       INTEGER       YEARDOY,YEAR,YR,DOY
       
+      DATA LastFileW /" "/
 
       PARAMETER (ERRKEY = 'MAKEFW')
       PARAMETER (BLANK = ' ')
@@ -311,83 +312,87 @@
          FILEWW = PATHWT(1:(PATHL-1)) // FILEW
       ENDIF
       
-      ICASAF  = 0
-      YEAR    = -99
-      DOY     = -99
-      YEARDOY = -99
+      !FO - Process FILEW if last FILEW is different.
+      IF(LastFileW /= FILEW) THEN
       
-      !FO - Rewind file because of BatchFiles runs that keep the same unit.
-      CALL GETLUN('FILEW', UNIT)
-      
-      INQUIRE(FILE=FILEWW, EXIST = FEXIST)
-      
-      
-      IF(FEXIST) THEN
-        OPEN (UNIT, FILE = FILEWW,STATUS = 'OLD',IOSTAT=ERRNUM)
-        IF (ERRNUM .NE. 0) CALL ERROR (ERRKEY,18,FILEW,0)
-      ELSE
-        CALL ERROR (ERRKEY,18,FILEW,0)
-      ENDIF
+        LastFileW = FILEW
+        
+        ICASAF  = 0
+        YEAR    = -99
+        DOY     = -99
+        YEARDOY = -99
+        
+        CALL GETLUN('FILEW', UNIT)
+        
+        INQUIRE(FILE=FILEWW, EXIST = FEXIST)
+        IF(FEXIST) THEN
+          OPEN (UNIT, FILE = FILEWW,STATUS = 'OLD',IOSTAT=ERRNUM)
+          IF (ERRNUM .NE. 0) CALL ERROR (ERRKEY,18,FILEW,0)
+        ELSE
+          CALL ERROR (ERRKEY,18,FILEW,0)
+        ENDIF
+              
+        DO WHILE (ERRNUM .EQ. 0)
+          READ (UNIT,'(A)', IOSTAT=ERRNUM) LINE
+          
+          !FO - Look for 1st header line beginning with '$'
+          IF(INDEX(LINE, '$WEATHER') .GT. 0 .AND. ICASAF .EQ. 0) THEN
+            ICASAF = 1  
+          
+          !FO - New Weather file format true read 7-digit. Otherwise keep the default.
+          ELSEIF(ICASAF .EQ. 1) THEN
             
-      DO WHILE (ERRNUM .EQ. 0)
-        READ (UNIT,'(A)', IOSTAT=ERRNUM) LINE
+            !FO - Look for header lines beginning with '@'  
+            IF(LINE(1:1) .EQ. '@' .AND. INDEX(LINE, 'DATE') .GT. 0) THEN
+                !FO - Read 7-digit First Weather YEAR
+                READ (UNIT,'(I7)', IOSTAT=ERRNUM) YEARDOY
+                IF (ERRNUM .NE. 0) CALL ERROR (ERRKEY,17,FILEW,0)
+                
+                EXIT
+            ELSE IF(LINE(1:1) .EQ. '@' .AND. INDEX(LINE, 'YEAR') .GT. 0) THEN
+                !FO - Read ICASA format
+                READ (UNIT,'(I4,1X,I3)', IOSTAT=ERRNUM) YEAR, DOY 
+                IF (ERRNUM .NE. 0) CALL ERROR (ERRKEY,17,FILEW,0)
+                
+                YEARDOY = YEAR * 1000 + DOY
+                
+                EXIT
+              ENDIF
+            ENDIF  
+            
+        ENDDO
         
-        !FO - Look for 1st header line beginning with '$'
-        IF(INDEX(LINE, '$WEATHER') .GT. 0 .AND. ICASAF .EQ. 0) THEN
-          ICASAF = 1  
+        CLOSE(UNIT)
         
-        !FO - New Weather file format true read 7-digit. Otherwise keep the default.
-        ELSEIF(ICASAF .EQ. 1) THEN
-          
-          !FO - Look for header lines beginning with '@'  
-          IF(LINE(1:1) .EQ. '@' .AND. INDEX(LINE, 'DATE') .GT. 0) THEN
-              !FO - Read 7-digit First Weather YEAR
-              READ (UNIT,'(I7)', IOSTAT=ERRNUM) YEARDOY
-              IF (ERRNUM .NE. 0) CALL ERROR (ERRKEY,17,FILEW,0)
-              
-              EXIT
-          ELSE IF(LINE(1:1) .EQ. '@' .AND. INDEX(LINE, 'YEAR') .GT. 0) THEN
-              !FO - Read ICASA format
-              READ (UNIT,'(I4,1X,I3)', IOSTAT=ERRNUM) YEAR, DOY 
-              IF (ERRNUM .NE. 0) CALL ERROR (ERRKEY,17,FILEW,0)
-              
-              YEARDOY = YEAR * 1000 + DOY
-              
-              EXIT
-            ENDIF
-          ENDIF  
-          
-      ENDDO
-      
-      CLOSE(UNIT)
-      
 !-----------------------------------------------------------------------
 !    Convert SDATE to 7-digits and check if is in the date range 
 !-----------------------------------------------------------------------      
-      
-      IF (YEARDOY .GT. 0 .AND. ICASAF .EQ. 1) THEN
-        FirstWeatherDate = YEARDOY
         
-        YEARDOY = INT(FirstWeatherDate/100000) * 100000 + YRDOY
-        
-        IF(YEARDOY .GE. FirstWeatherDate) THEN
-          NEWSDATE = YEARDOY
+        IF (YEARDOY .GT. 0 .AND. ICASAF .EQ. 1) THEN
+          FirstWeatherDate = YEARDOY
+          
+          YEARDOY = INT(FirstWeatherDate/100000) * 100000 + YRDOY
+          
+          IF(YEARDOY .GE. FirstWeatherDate) THEN
+            NEWSDATE = YEARDOY
+          ELSE
+            NEWSDATE = INT((FirstWeatherDate+99000)/100000)*100000+YRDOY
+          ENDIF
+          
+          ! Error Checking
+          IF(NEWSDATE .LT. FirstWeatherDate .OR. NEWSDATE .GT. FirstWeatherDate+99000) THEN
+            CALL ERROR (ERRKEY,19,FILEX,0)
+          ENDIF
+          
         ELSE
-          NEWSDATE = INT((FirstWeatherDate+99000)/100000)*100000+YRDOY
+          MSG(1) = 'Y4KDOY - Weather file'
+          MSG(2) = 'Not able to find 7-digits first weather date'
+          MSG(3) = 'Set simulation to 5-digits first weather date'
+          FirstWeatherDate = -99
+          
+          CALL WARNING(3,ERRKEY,MSG)
         ENDIF
-        
-        ! Error Checking
-        IF(NEWSDATE .LT. FirstWeatherDate .OR. NEWSDATE .GT. FirstWeatherDate+99000) THEN
-          CALL ERROR (ERRKEY,19,FILEX,0)
-        ENDIF
-        
-      ELSE
-        MSG(1) = 'Y4KDOY - Weather file'
-        MSG(2) = 'Not able to find 7-digits first weather date'
-        MSG(3) = 'Set simulation to 5-digits first weather date'
-        FirstWeatherDate = -99
-        
-        CALL WARNING(3,ERRKEY,MSG)
+      
       ENDIF
       
     END SUBROUTINE MAKEFILEW

--- a/Weather/IPWTH_alt.for
+++ b/Weather/IPWTH_alt.for
@@ -354,13 +354,34 @@ C       Substitute default values if REFHT or WINDHT are missing.
 
       ELSEIF (LongFile .AND. YRDOY < FirstWeatherDay) THEN
 !       Starting over with long file -- same file, but need to read from top
-        REWIND(LUNWTH)
+        INQUIRE(FILE=FILEWW,EXIST=FEXIST)
+        
+        IF (.NOT. FEXIST) THEN
+          ErrCode = 30
+          CALL WeatherError(CONTROL, ErrCode, FILEWW, 0, YRDOYWY, YREND)
+          RETURN
+        ENDIF
+        
+        OPEN (LUNWTH,FILE=FILEWW,STATUS='OLD',IOSTAT=ERR)
+        IF (ERR /= 0) THEN
+          ErrCode = 29
+          CALL WeatherError(CONTROL, ErrCode, FILEWW, 0, YRDOYWY, YREND)
+          RETURN
+        ENDIF
+        
+        !INQUIRE(UNIT=LUNWTH,EXIST=FEXIST)
+        !REWIND(LUNWTH, IOSTAT=ErrCode, ERR=722)
+        
+  722   IF(ErrCode .NE. 0) CALL ERROR(ERRKEY,30,FILEW,LINWTH)
+        
+
+        
   200   CONTINUE
         CALL IGNORE(LUNWTH,LINWTH,FOUND,LINE)
         IF (FOUND == 2) GO TO 200
         IF (FOUND == 0) CALL ERROR(ERRKEY,-1,FILEW,LINWTH)
         NRecords = 0
-
+        
       ELSEIF (LongFile .AND. YRDOY > LastWeatherDay) THEN
 !       Need to get next batch of records from long file
         NRecords = 0

--- a/Weather/IPWTH_alt.for
+++ b/Weather/IPWTH_alt.for
@@ -353,28 +353,8 @@ C       Substitute default values if REFHT or WINDHT are missing.
         NRecords = 0
 
       ELSEIF (LongFile .AND. YRDOY < FirstWeatherDay) THEN
-!       Starting over with long file -- same file, but need to read from top
-        INQUIRE(FILE=FILEWW,EXIST=FEXIST)
-        
-        IF (.NOT. FEXIST) THEN
-          ErrCode = 30
-          CALL WeatherError(CONTROL, ErrCode, FILEWW, 0, YRDOYWY, YREND)
-          RETURN
-        ENDIF
-        
-        OPEN (LUNWTH,FILE=FILEWW,STATUS='OLD',IOSTAT=ERR)
-        IF (ERR /= 0) THEN
-          ErrCode = 29
-          CALL WeatherError(CONTROL, ErrCode, FILEWW, 0, YRDOYWY, YREND)
-          RETURN
-        ENDIF
-        
-        !INQUIRE(UNIT=LUNWTH,EXIST=FEXIST)
-        !REWIND(LUNWTH, IOSTAT=ErrCode, ERR=722)
-        
-  722   IF(ErrCode .NE. 0) CALL ERROR(ERRKEY,30,FILEW,LINWTH)
-        
-
+!       Starting over with long file -- same file, but need to read from tops
+        REWIND(LUNWTH)
         
   200   CONTINUE
         CALL IGNORE(LUNWTH,LINWTH,FOUND,LINE)


### PR DESCRIPTION
This problem caused the model to stop when changing treatments for an experiment. The solution was to add protection for the code that checks if the weather file is Y4K in the MAKEFILEW subroutine.