### PR TITLE
Edits to commenting and order of short and tall crop parameter reads.

### DIFF
--- a/Data/Genotype/COGRO047.SPE
+++ b/Data/Genotype/COGRO047.SPE
@@ -133,8 +133,8 @@
 
 !*EVAPOTRANSPIRATION
   0.70   1.1       KEP,  EORATIO
-  0.50  0.96       TSKC, TKCBmax ASCE tall ref (50 cm alfalfa)
   0.50  1.15       SSKC, SKCBmax ASCE short ref (12 cm grass)
+  0.50  0.96       TSKC, TKCBmax ASCE tall ref (50 cm alfalfa)
 
 *PHOSPHORUS CONTENT
 ! Two options for Optimum and minimum P concentrations for shoots: 

--- a/Data/Genotype/SBGRO047.SPE
+++ b/Data/Genotype/SBGRO047.SPE
@@ -149,8 +149,8 @@
 
 !*EVAPOTRANSPIRATION
   0.68   1.1       KEP, EORATIO
-  0.50  0.95       TSKC, TKCBmax ASCE tall ref (50 cm alfalfa)
   0.50  1.10       SSKC, SKCBmax ASCE short ref (12 cm grass)
+  0.50  0.95       TSKC, TKCBmax ASCE tall ref (50 cm alfalfa)
 
 *PHOSPHORUS CONTENT
 ! Two options for Optimum and minimum P concentrations for shoots: 

--- a/Plant/CROPGRO/IPPLNT.for
+++ b/Plant/CROPGRO/IPPLNT.for
@@ -65,7 +65,6 @@ C-----------------------------------------------------------------------
 !     Species-dependant variables exported to SPAM or WATBAL:
       REAL EORATIO, KCAN, KEP, PORMIN, RWUMX, RWUEP1
       REAL KCAN_ECO, KC_SLOPE
-!     REAL SSKC, SKCBMAX, TSKC, TKCBMAX
 
 !     Species parameters for N stress  9/11/2008
 !     REAL NSTR_FAC, NSTR_EXP, NRAT_FAC, EXCS_FAC, EXCS_EXP
@@ -510,10 +509,6 @@ C-----------------------------------------------------------------------
 !            (g[CH2O] / g[product])
 ! RPRO     Respiration required for re-synthesizing protein from mobilized 
 !            N (g[CH2O] / g[protein])
-! SKCBMAX  Maximum basal crop coefficient, ASCE dual Kc short crop ET method
-! SSKC     Shaping coefficient, ASCE dual Kc short crop ET method
-! TKCBMAX  Maximum basal crop coefficient, ASCE dual Kc tall crop ET method
-! TSKC     Shaping coefficient, ASCE dual Kc tall crop ET method
 ! TTFIX    Physiological days delay in nodule initiation
 !            (photo-thermal days / day)
 !-----------------------------------------------------------------------

--- a/Plant/plant.for
+++ b/Plant/plant.for
@@ -862,11 +862,22 @@ c     Total LAI must exceed or be equal to healthy LAI:
           GOTO 100
         ELSE
           CALL IGNORE(LUNCRP,LNUM,ISECT,CHAR)
+          !KEP and EORATIO are not used in ASCE PET method,
+          !but must be read in prior to ASCE parameters.
           READ(CHAR,'(2F6.0)',IOSTAT=ERR) KEP, EORATIO
           IF (ERR .NE. 0) THEN
             NMSG = NMSG + 1
-            MSG(NMSG)="Error reading KEP, EORATIO for ASCE PET method."
+            MSG(NMSG)="Error reading KEP and EORATIO."
           ENDIF
+        ENDIF
+        
+!       Read short reference crop parameters
+        CALL IGNORE(LUNCRP,LNUM,ISECT,CHAR)
+        IF(ISECT .NE. 1) CALL ERROR (ERRKEY,1,FILECC,LNUM)
+        READ(CHAR,'(2F6.0)',IOSTAT=ERR) SSKC, SKCBMAX
+        IF (ERR .NE. 0) THEN
+          NMSG = NMSG + 1
+          MSG(NMSG)="Error reading SSKC, SKCBMAX for ASCE PET method."
         ENDIF
 
 !       Read tall reference crop parameters
@@ -876,15 +887,6 @@ c     Total LAI must exceed or be equal to healthy LAI:
         IF (ERR .NE. 0) THEN
           NMSG = NMSG + 1
           MSG(NMSG)="Error reading TSKC, TKCBMAX for ASCE PET method."
-        ENDIF
-
-!       Read short reference crop parameters
-        CALL IGNORE(LUNCRP,LNUM,ISECT,CHAR)
-        IF(ISECT .NE. 1) CALL ERROR (ERRKEY,1,FILECC,LNUM)
-        READ(CHAR,'(2F6.0)',IOSTAT=ERR) SSKC, SKCBMAX
-        IF (ERR .NE. 0) THEN
-          NMSG = NMSG + 1
-          MSG(NMSG)="Error reading SSKC, SKCBMAX for ASCE PET method."
         ENDIF
 
         CLOSE (LUNCRP)
@@ -909,7 +911,7 @@ c     Total LAI must exceed or be equal to healthy LAI:
         CALL ERROR(ERRKEY,1,FILECC,LNUM)
       ENDIF
 
-!     Store the values for retreival in SPAM.
+!     Store the values for retrieval in SPAM (actually in PET.for).
       IF (MEEVP.EQ.'S') THEN
         CALL PUT('SPAM', 'SKC', SSKC)
         CALL PUT('SPAM', 'KCBMAX', SKCBMAX)

--- a/SPAM/PET.for
+++ b/SPAM/PET.for
@@ -7,14 +7,19 @@
 !  MEEVP Routine Description
 !   S  PETASCE ASCE Standardized Reference Evapotranspiration Equation
 !                for the short reference crop (12-cm grass) with dual
-!                FAO-56 crop coefficient method
+!                FAO-56 crop coefficient method (potential E and T 
+!                calculated independently).
 !   T  PETASCE ASCE Standardized Reference Evapotranspiration Equation
 !                for the tall reference crop (50-cm alfalfa) with dual
-!                FAO-56 crop coefficient method
+!                FAO-56 crop coefficient method (potential E and T
+!                calculated independently).
 !   R  PETPT   Calculates Priestley-Taylor potential evapotranspiration
-!                (default method)
-!   F  PETPEN  FAO Penman-Monteith (FAO-56) potential evapotranspiration, 
-!                with KC = 1.0
+!                (default method with potential E and T partitioned as a
+!                function of LAI).
+!   F  PETPEN  FAO Penman-Monteith (FAO-56) reference evapotranspiration 
+!                with EORATIO adjustment for CROPGRO models and KC = 1.0
+!                for non-CROPGRO models (potential E and T partioned as 
+!                a function of LAI).
 !   D  PETDYN  Dynamic Penman-Monteith, pot. evapotranspiration, with
 !                dynamic input of LAI, crop height effects on Ra and Rs
 !   P  PETPNO  FAO Penman (FAO-24) potential evapotranspiration 
@@ -131,7 +136,8 @@ C  reference crops using the ASCE Standardized Reference
 C  Evapotranspiration Equation.
 C  Adjusts reference evapotranspiration to potential soil water 
 C  evaporation and potential transpiration using FAO-56 dual crop
-C  coefficients.
+C  coefficients, following FAO-56 (Allen et al., 1998) and the
+C  ASCE (2005) standardized reference ET algorithm.
 C  DeJonge K. C., Thorp, K. R., 2017. Implementing standardized
 C  reference evapotranspiration and dual crop coefficient approach
 C  in the DSSAT Cropping System Model. Transactions of the ASABE. 
@@ -262,9 +268,13 @@ C=======================================================================
       CALL GET('SPAM', 'SKC', SKC)
       KCBMIN = 0.0
       CALL GET('SPAM', 'KCBMAX', KCBMAX)
-      IF (SKC .LT. 1.E-6 .OR. KCBMAX .LT. 1.E-6) THEN
-          MSG(1) = "Crop coefficient parameters for the ASCE dual Kc"
-          MSG(2) = "ET method are not available for this crop."
+      IF (SKC .LT. 0.30 .OR. SKC .GT. 1.0) THEN
+          MSG(1) = "SKC for ASCE PET method is out of range."
+          CALL WARNING(2,"PET",MSG)
+          CALL ERROR("CSM",64,"",0)
+      ENDIF
+      IF (KCBMAX .LT. 0.25 .OR. KCBMAX .GT. 1.5) THEN
+          MSG(1) = "KCBMAX for ASCE PET method is out of range."
           CALL WARNING(2,"PET",MSG)
           CALL ERROR("CSM",64,"",0)
       ENDIF
@@ -276,7 +286,7 @@ C=======================================================================
          KCB = 0.0
       ELSE
          !Equation from DeJonge et al. (2012) Agricultural Water
-         !Management 115, 92-103
+         !Management 115, 92-103 and revised in DeJonge and Thorp (2017)
          KCB = MAX(0.0,KCBMIN+(KCBMAX-KCBMIN)*(1.0-EXP(-1.0*SKC*XHLAI)))
       ENDIF
 


### PR DESCRIPTION
Minor edits to commented lines throughout the ASCE PET routine.

A major change is to switch the order of reading the short and tall crop parameters in the SPE files.  I originally had the short crop parameters read in first, because it is the most commonly used reference ET method.