### PR TITLE
Avoid multiple headers in the evaluate.out file for CROPSIM based models

### DIFF
--- a/Plant/CSCER_CSCRP_CSCAS/CSCAS.for
+++ b/Plant/CSCER_CSCRP_CSCAS/CSCAS.for
@@ -7830,12 +7830,12 @@ c           ENDIF
               IF (RUN.EQ.1) THEN
                 EVALOUT = 0
                 EVHEADNM = 0
-                EVHEADNMMAX = 7
+                EVHEADNMMAX = 1
               ENDIF
               IF (EXCODE.NE.EXCODEPREV) THEN
                 EVHEADNM = EVHEADNM + 1
                 OPEN (UNIT=FNUMEVAL,FILE=FNAMEEVAL,POSITION='APPEND')
-                IF (EVHEADNM.LT.EVHEADNMMAX.AND.EVHEADNMMAX.GT.1) THEN
+                IF (EVHEADNM.LE.EVHEADNMMAX.AND.EVHEADNMMAX.GE.1) THEN
                   LENENAME = TVILENT(ENAME)
                   WRITE (FNUMEVAL,*) ' '
                   WRITE (FNUMEVAL,993) 

--- a/Plant/CSCER_CSCRP_CSCAS/CSCER.for
+++ b/Plant/CSCER_CSCRP_CSCAS/CSCER.for
@@ -7806,14 +7806,14 @@ C-GH      IF (snow.GT.0) THEN
                EVHEADNM = 0
               ENDIF
               
-              IF (EVHEADNM.LT.7) THEN
+              IF (EVHEADNM.EQ.0) THEN
                 IF (EXCODE.NE.EXCODEP.AND.EVALOUT.GT.1 .OR.
      &              RUN.EQ.1.AND.RUNI.EQ.1) THEN
                  EVHEADNM = EVHEADNM + 1
                  OPEN (UNIT = FNUMTMP,FILE = FNAMETMP,
      &            POSITION = 'APPEND')
                  WRITE (FNUMTMP,*) ' '
-                 IF (EVHEADNM.LT.7) THEN
+                 IF (EVHEADNM.EQ.1) THEN
                    WRITE (FNUMTMP,993) EVHEADER,EXCODE,
      &              ENAME(1:25),MODNAME
   993              FORMAT (A14,A10,'  ',A25,2X,A8,/)

--- a/Plant/CSCER_CSCRP_CSCAS/CSCRP.for
+++ b/Plant/CSCER_CSCRP_CSCAS/CSCRP.for
@@ -10574,12 +10574,12 @@ C  FO - 05/07/2020 Add new Y4K subroutine call to convert YRDOY
               IF (RUN.EQ.1) THEN
                 EVALOUT = 0
                 EVHEADNM = 0
-                EVHEADNMMAX = 7
+                EVHEADNMMAX = 1
               ENDIF
               IF (EXCODE.NE.EXCODEPREV) THEN
                 EVHEADNM = EVHEADNM + 1
                 OPEN (UNIT=FNUMEVAL,FILE=FNAMEEVAL,POSITION='APPEND')
-                IF (EVHEADNM.LT.EVHEADNMMAX.AND.EVHEADNMMAX.GT.1) THEN
+                IF (EVHEADNM.LE.EVHEADNMMAX.AND.EVHEADNMMAX.GE.1) THEN
                   LENENAME = TVILENT(ENAME)
                   WRITE (FNUMEVAL,*) ' '
                   WRITE (FNUMEVAL,993) 

--- a/Plant/CSYCA-Cassava/YCA_Out_Eval.f90
+++ b/Plant/CSYCA-Cassava/YCA_Out_Eval.f90
@@ -565,12 +565,12 @@
                     IF (RUN == 1) THEN
                         EVALOUT = 0
                         EVHEADNM = 0
-                        EVHEADNMMAX = 7
+                        EVHEADNMMAX = 1
                     ENDIF
                     IF (EXCODE /= EXCODEPREV) THEN
                         EVHEADNM = EVHEADNM + 1
                         OPEN (UNIT=FNUMEVAL,FILE=FNAMEEVAL,POSITION='APPEND')
-                        IF (EVHEADNM < EVHEADNMMAX.AND.EVHEADNMMAX > 1) THEN
+                        IF (EVHEADNM <= EVHEADNMMAX.AND.EVHEADNMMAX >= 1) THEN
                             LENENAME = TVILENT(ENAME)
                             WRITE (FNUMEVAL,*) ' '
                             WRITE (FNUMEVAL, FMT993) EVHEADER,EXCODE,ENAME(1:25),MODNAME


### PR DESCRIPTION
This includes: CSYCA, CSCAS, CSCER (wheat and barley) and CSCRP (wheat, barley)