### PR TITLE
Minor changes to build settings.

### DIFF
--- a/cmake/Modules/SetFortranFlags.cmake
+++ b/cmake/Modules/SetFortranFlags.cmake
@@ -23,10 +23,10 @@ ELSEIF(BT STREQUAL "TESTING")
       "Choose the type of build, options are DEBUG, RELEASE, or TESTING."
       FORCE)
 ELSEIF(NOT BT)
-    SET(CMAKE_BUILD_TYPE DEBUG CACHE STRING
+    SET(CMAKE_BUILD_TYPE RELEASE CACHE STRING
       "Choose the type of build, options are DEBUG, RELEASE, or TESTING."
       FORCE)
-    MESSAGE(STATUS "CMAKE_BUILD_TYPE not given, defaulting to DEBUG")
+    MESSAGE(STATUS "CMAKE_BUILD_TYPE not given, defaulting to RELEASE")
 ELSE()
     MESSAGE(FATAL_ERROR "CMAKE_BUILD_TYPE not valid, choices are DEBUG, RELEASE, or TESTING")
 ENDIF(BT STREQUAL "RELEASE")
@@ -118,6 +118,13 @@ SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
                  Fortran "-mmacosx-version-min=10.10.0"
                 )
+
+# Set install directory for Linux same as STDPATH in OSDefsLINUX.for
+# This will create the appropriate DSSATPRO.Lxx file that works with STDPATH
+IF(UNIX)
+    SET(CMAKE_INSTALL_PREFIX "/DSSAT48" CACHE PATH "Path to installation directory" FORCE)
+ENDIF(UNIX)
+
 ####################
 ### LINKER FLAGS ###
 ####################


### PR DESCRIPTION
This resolves a couple discrepancies I've noticed.

1. The README.md file (and Github cover page) states that the default build type is RELEASE (under "Configuring the build").  However, the SetFortranFlags.cmake file currents specifies the default build type as DEBUG.  I modified this to be RELEASE.

2. The STDPATH for Linux is '/DSSAT48/' in OSDefsLinux.for. However, cmake currently results a DSSATPRO.L48 file with 'usr/local' as the path.  To bring some consistency, I modified SetFortranFlags.cmake to specify the install directory as '/DSSAT48' for builds on Linux.