### PR TITLE
Stop model for undefined PET flag.

### DIFF
--- a/Data/MODEL.ERR
+++ b/Data/MODEL.ERR
@@ -706,15 +706,6 @@ Path error in configuration file. Please correct file.
 PET       1
 Undefined EVAPO parameter in FileX.
 
-PETASC    1
-SKC for ASCE PET method is out of range. Check species file.
-
-PETASC    2
-KCBMAX for ASCE PET method is out of range. Check species file.
-
-PETASC   50
-ASCE reference ET method is not available for this crop.
-
 PPLANT   10
 Review P parameters in species file.
 

--- a/Data/MODEL.ERR
+++ b/Data/MODEL.ERR
@@ -703,7 +703,16 @@ Configuration file not found.
 PATH      3
 Path error in configuration file. Please correct file.
 
-PETASCE  50
+PET       1
+Undefined EVAPO parameter in FileX.
+
+PETASC    1
+SKC for ASCE PET method is out of range. Check species file.
+
+PETASC    2
+KCBMAX for ASCE PET method is out of range. Check species file.
+
+PETASC   50
 ASCE reference ET method is not available for this crop.
 
 PPLANT   10

--- a/Plant/plant.for
+++ b/Plant/plant.for
@@ -845,7 +845,7 @@ c     Total LAI must exceed or be equal to healthy LAI:
 
       CHARACTER*12 FILEC
       CHARACTER*30 FILEIO
-      CHARACTER*78 MSG(6)
+      CHARACTER*78 MSG(10)
       CHARACTER*80 PATHCR, CHAR
       CHARACTER*92 FILECC
 
@@ -929,11 +929,29 @@ c     Total LAI must exceed or be equal to healthy LAI:
 
         CLOSE (LUNCRP)
 
-!       Check for value with valid ranges.
-        SSKC    = MAX(0.30,MIN(1.0,SSKC))
-        SKCBMAX = MAX(0.25,MIN(1.5,SKCBMAX))
-        TSKC    = MAX(0.30,MIN(1.0,TSKC))
-        TKCBMAX = MAX(0.25,MIN(1.5,TKCBMAX))
+!       Check for values with valid ranges.
+        IF (MEEVP .EQ. 'S') THEN
+          IF (SSKC .LT. 0.30 .OR. SSKC .GT. 1.0) THEN
+            NMSG = NMSG + 1
+            MSG(NMSG) = "SSKC for ASCE PET method is out of range."
+          ENDIF
+          IF (SKCBMAX .LT. 0.25 .OR. SKCBMAX .GT. 1.5) THEN
+            NMSG = NMSG + 1
+            MSG(NMSG) = "SKCBMAX for ASCE PET method is out of range."
+          ENDIF
+        ENDIF
+        
+        IF (MEEVP .EQ. 'T') THEN
+          IF (TSKC .LT. 0.30 .OR. TSKC .GT. 1.0) THEN
+            NMSG = NMSG + 1
+            MSG(NMSG) = "TSKC for ASCE PET method is out of range."
+          ENDIF
+          IF (TKCBMAX .LT. 0.25 .OR. TKCBMAX .GT. 1.5) THEN
+            NMSG = NMSG + 1
+            MSG(NMSG) = "TKCBMAX for ASCE PET method is out of range."
+          ENDIF
+        ENDIF
+        
       ELSE
 !       If fallow, use minimum values
         SSKC    = 0.30

--- a/SPAM/PET.for
+++ b/SPAM/PET.for
@@ -213,8 +213,6 @@ C=======================================================================
       REAL FCD, TK4, RNL, RN, G, WINDSP, WIND2m, Cn, Cd, KCMAX, RHMIN
       REAL WND, CHT
       REAL REFET, SKC, KCBMIN, KCBMAX, KCB, KE, KC
-      CHARACTER*78 MSG(2)
-      CHARACTER*6, PARAMETER :: ERRKEY = "PETASC"
 !-----------------------------------------------------------------------
 
 !     ASCE Standardized Reference Evapotranspiration
@@ -304,16 +302,6 @@ C=======================================================================
       CALL GET('SPAM', 'SKC', SKC)
       KCBMIN = 0.0
       CALL GET('SPAM', 'KCBMAX', KCBMAX)
-      IF (SKC .LT. 0.30 .OR. SKC .GT. 1.0) THEN
-          MSG(1) = "SKC for ASCE PET method is out of range."
-          CALL WARNING(2,ERRKEY,MSG)
-          CALL ERROR(ERRKEY,1,"",0)
-      ENDIF
-      IF (KCBMAX .LT. 0.25 .OR. KCBMAX .GT. 1.5) THEN
-          MSG(1) = "KCBMAX for ASCE PET method is out of range."
-          CALL WARNING(2,ERRKEY,MSG)
-          CALL ERROR(ERRKEY,2,"",0)
-      ENDIF
 
 !     Basal crop coefficient (Kcb)
 !     Also similar to FAO-56 Eq. 97

--- a/SPAM/PET.for
+++ b/SPAM/PET.for
@@ -59,6 +59,8 @@ C=======================================================================
       REAL WINDRUN, XLAT, XELEV
       REAL, DIMENSION(TS)    ::RADHR, TAIRHR, ET0
       CHARACTER*78  MSG(2)
+      CHARACTER*12 FILEX
+      CHARACTER*6, PARAMETER :: ERRKEY = "PET   "
       
       CLOUDS = WEATHER % CLOUDS
       SRAD   = WEATHER % SRAD  
@@ -76,6 +78,7 @@ C=======================================================================
       TAIRHR = WEATHER % TAIRHR
       
       YRDOY = CONTROL % YRDOY
+      FILEX = CONTROL % FILEX
       CALL YR_DOY(YRDOY, YEAR, DOY)
 
       SELECT CASE (MEEVP)
@@ -140,8 +143,8 @@ C=======================================================================
           CASE DEFAULT
               MSG(1) = "Undefined EVAPO parameter in FileX."
               MSG(2) = "Unknown MEEVP in PET.for."
-              CALL WARNING(2,"PET",MSG)
-              CALL ERROR("CSM",64,"",0)
+              CALL WARNING(2,ERRKEY,MSG)
+              CALL ERROR(ERRKEY,1,FILEX,0)
 !         ------------------------
       END SELECT
 
@@ -211,6 +214,7 @@ C=======================================================================
       REAL WND, CHT
       REAL REFET, SKC, KCBMIN, KCBMAX, KCB, KE, KC
       CHARACTER*78 MSG(2)
+      CHARACTER*6, PARAMETER :: ERRKEY = "PETASC"
 !-----------------------------------------------------------------------
 
 !     ASCE Standardized Reference Evapotranspiration
@@ -302,13 +306,13 @@ C=======================================================================
       CALL GET('SPAM', 'KCBMAX', KCBMAX)
       IF (SKC .LT. 0.30 .OR. SKC .GT. 1.0) THEN
           MSG(1) = "SKC for ASCE PET method is out of range."
-          CALL WARNING(2,"PET",MSG)
-          CALL ERROR("CSM",64,"",0)
+          CALL WARNING(2,ERRKEY,MSG)
+          CALL ERROR(ERRKEY,1,"",0)
       ENDIF
       IF (KCBMAX .LT. 0.25 .OR. KCBMAX .GT. 1.5) THEN
           MSG(1) = "KCBMAX for ASCE PET method is out of range."
-          CALL WARNING(2,"PET",MSG)
-          CALL ERROR("CSM",64,"",0)
+          CALL WARNING(2,ERRKEY,MSG)
+          CALL ERROR(ERRKEY,2,"",0)
       ENDIF
 
 !     Basal crop coefficient (Kcb)

--- a/SPAM/PET.for
+++ b/SPAM/PET.for
@@ -58,6 +58,7 @@ C=======================================================================
       REAL TDEW, TMAX, TMIN, VAPR, WINDHT, WINDSP, XHLAI
       REAL WINDRUN, XLAT, XELEV
       REAL, DIMENSION(TS)    ::RADHR, TAIRHR, ET0
+      CHARACTER*78  MSG(2)
       
       CLOUDS = WEATHER % CLOUDS
       SRAD   = WEATHER % SRAD  
@@ -78,6 +79,12 @@ C=======================================================================
       CALL YR_DOY(YRDOY, YEAR, DOY)
 
       SELECT CASE (MEEVP)
+!         ------------------------
+          !Priestley-Taylor potential evapotranspiration
+          CASE ('R')
+            CALL PETPT(
+     &        ET_ALB, SRAD, TMAX, TMIN, XHLAI,          !Input
+     &        EO)                                       !Output
 !         ------------------------
           !FAO Penman-Monteith (FAO-56) potential evapotranspiration, 
 !             with KC = 1.0
@@ -123,18 +130,18 @@ C=======================================================================
           !CASE ('O')
           !    EO = EOMEAS
 !         ------------------------
-          !Priestly-Taylor potential evapotranspiration hourly
+          !Priestley-Taylor potential evapotranspiration hourly
           !including a VPD effect on transpiration
           CASE ('H')
               CALL PETPTH(
      &        ET_ALB, TMAX, XHLAI, RADHR, TAIRHR,       !Input
      &        EO, ET0)                                  !Output
 !         ------------------------
-          !Priestly-Taylor potential evapotranspiration
-          CASE DEFAULT !Default - MEEVP = 'R' 
-            CALL PETPT(
-     &        ET_ALB, SRAD, TMAX, TMIN, XHLAI,          !Input
-     &        EO)                                       !Output
+          CASE DEFAULT
+              MSG(1) = "Undefined EVAPO parameter in FileX."
+              MSG(2) = "Unknown MEEVP in PET.for."
+              CALL WARNING(2,"PET",MSG)
+              CALL ERROR("CSM",64,"",0)
 !         ------------------------
       END SELECT
 


### PR DESCRIPTION
Currently, the model defaults to the Priestley-Taylor PET method as a last resort in a SELECT CASE structure.  This has tripped me up on occasion when working with the ET algorithms.  If the model does not recognize the EVAPO flag in FileX, it will default to PT without warning.  I think it's better to define Priestley-Taylor explicitly (MEEVP="R") in the SELECT CASE structure, and stop the model if it does not recognize the PET flag.