### PR TITLE
Enable using PAR from weather file in maize, wheat and Barley models

### DIFF
--- a/Plant/CERES-Maize/MZ_CERES.for
+++ b/Plant/CERES-Maize/MZ_CERES.for
@@ -217,6 +217,7 @@ C      REAL            PRLF
 
 !     added for using PAR from weather file
       REAL        PAR 
+      LOGICAL     NOPAR
 
 !     ------------------------------------------------------------------
 !     Define constructed variable types based on definitions in
@@ -266,6 +267,7 @@ C      REAL            PRLF
       TMIN   = WEATHER % TMIN
       TWILEN = WEATHER % TWILEN
       PAR    = WEATHER % PAR   
+      NOPAR  = WEATHER % NOPAR 
 
       DATA MZSTGNAM /
      &  'End Juveni',   !1
@@ -347,7 +349,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR, NOPAR,              !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -500,7 +502,7 @@ C-----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR, NOPAR,              !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -664,7 +666,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR, NOPAR,              !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -765,7 +767,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR, NOPAR,              !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -873,7 +875,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR, NOPAR,              !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output

--- a/Plant/CERES-Maize/MZ_CERES.for
+++ b/Plant/CERES-Maize/MZ_CERES.for
@@ -193,7 +193,7 @@ C      REAL            PRLF
       INTEGER         YREMRG   
       INTEGER         YRPLT 
       INTEGER         YRSIM    
-	REAL            Z2STAGE
+	 REAL            Z2STAGE
 
 !     Added by W.D.B. for pest damage at CIMMYT 4/14/2001
 
@@ -214,6 +214,9 @@ C      REAL            PRLF
 
 !     Added for K model   
       REAL KUptake(NL), SKi_AVAIL(NL), KSTRES
+
+!     added for using PAR from weather file
+      REAL        PAR 
 
 !     ------------------------------------------------------------------
 !     Define constructed variable types based on definitions in
@@ -262,6 +265,7 @@ C      REAL            PRLF
       TMAX   = WEATHER % TMAX
       TMIN   = WEATHER % TMIN
       TWILEN = WEATHER % TWILEN
+      PAR    = WEATHER % PAR   
 
       DATA MZSTGNAM /
      &  'End Juveni',   !1
@@ -329,7 +333,7 @@ C----------------------------------------------------------------------
      &    CUMDTT,DTT,GPP,ISDATE, ISTAGE,MDATE,STGDOY,SUMDTT,      !O
      &    XNTI,TLNO,XSTAGE,YREMRG,RUE,KCAN,KEP, P3, TSEN, CDAY,   !O
      &    PEAR,PSTM,GDDAE,SeedFrac,VegFrac,Z2STAGE,CropStatus)    !O
-	    ENDIF
+	     ENDIF
 
           !-------------------------------------------------------------
           !Call growth routine
@@ -343,7 +347,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail,                          !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -365,7 +369,7 @@ C----------------------------------------------------------------------
      &      SeedFrac,SHF,SLPF,SPi_AVAIL,SRAD,STGDOY,SUMDTT,SW,  !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,     !Input
      &      WEATHER,WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,       !Input
-     &      YRDOY, YRPLT, Z2STAGE,                              !Input
+     &      YRDOY, YRPLT, Z2STAGE, PAR,                         !Input
      &      EARS, GPP, MDATE,                                   !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,      !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,    !Output
@@ -386,7 +390,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT,                                     !Input
+     &      YRDOY, YRPLT, PAR,                                !Input
      &      EARS, GPP, MDATE,                                 !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -478,14 +482,14 @@ C-----------------------------------------------------------------------
      &      CUMDTT,DTT,EARS,GPP,ISDATE, ISTAGE,MDATE,STGDOY,SUMDTT, !O
      &      XNTI,TLNO,XSTAGE,YREMRG,RUE,KCAN,KEP, P3, TSEN, CDAY,   !O
      &      SeedFrac, VegFrac, CropStatus)                          !O
-	    ELSEIF(MODEL(1:5).EQ.'MZIXM')THEN
+	     ELSEIF(MODEL(1:5).EQ.'MZIXM')THEN
             CALL MZ_IX_PHENOL(DYNAMIC,ISWWAT,FILEIO,IDETO,        !C
      &    CUMDEP,DAYL,DLAYR,LEAFNO,LL,NLAYR,PLTPOP,SDEPTH,        !I
      &    SNOW, SRAD,SW,TMAX,TMIN, TWILEN,XN,YRDOY,YRSIM,         !I
      &    CUMDTT,DTT,GPP,ISDATE, ISTAGE,MDATE,STGDOY,SUMDTT,      !O
      &    XNTI,TLNO,XSTAGE,YREMRG,RUE,KCAN,KEP, P3, TSEN, CDAY,   !O
      &    PEAR,PSTM,GDDAE,SeedFrac,VegFrac,Z2STAGE,CropStatus)    !O
-	    ENDIF
+	     ENDIF
 
           SELECT CASE(MODEL(1:5))
           CASE ('MZCER')  !CERES-Maize
@@ -496,7 +500,7 @@ C-----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail,                          !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -518,7 +522,7 @@ C-----------------------------------------------------------------------
      &      SeedFrac,SHF,SLPF,SPi_AVAIL,SRAD,STGDOY,SUMDTT,SW,  !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,     !Input
      &      WEATHER,WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,       !Input
-     &      YRDOY, YRPLT, Z2STAGE,                              !Input
+     &      YRDOY, YRPLT, Z2STAGE, PAR,                         !Input
      &      EARS, GPP, MDATE,                                   !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,      !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,    !Output
@@ -539,7 +543,7 @@ C-----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT,                                     !Input
+     &      YRDOY, YRPLT, PAR,                                !Input
      &      EARS, GPP, MDATE,                                 !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -637,14 +641,14 @@ C----------------------------------------------------------------------
      &        CUMDTT,DTT,EARS,GPP,ISDATE, ISTAGE,MDATE,STGDOY,SUMDTT, !O
      &        XNTI,TLNO,XSTAGE,YREMRG,RUE,KCAN,KEP, P3, TSEN, CDAY,   !O
      &        SeedFrac, VegFrac, CropStatus)                          !O
-	      ELSEIF(MODEL(1:5).EQ.'MZIXM')THEN
+	       ELSEIF(MODEL(1:5).EQ.'MZIXM')THEN
               CALL MZ_IX_PHENOL(DYNAMIC,ISWWAT,FILEIO,IDETO,      !C
      &    CUMDEP,DAYL,DLAYR,LEAFNO,LL,NLAYR,PLTPOP,SDEPTH,        !I
      &    SNOW, SRAD,SW,TMAX,TMIN, TWILEN,XN,YRDOY,YRSIM,         !I
      &    CUMDTT,DTT,GPP,ISDATE, ISTAGE,MDATE,STGDOY,SUMDTT,      !O
      &    XNTI,TLNO,XSTAGE,YREMRG,RUE,KCAN,KEP, P3, TSEN, CDAY,   !O
      &    PEAR,PSTM,GDDAE,SeedFrac,VegFrac,Z2STAGE,CropStatus)    !O
-	      ENDIF
+	       ENDIF
           ENDIF
         ENDIF
           !------------------------------------------------------------
@@ -660,7 +664,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail,                          !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -683,7 +687,7 @@ C----------------------------------------------------------------------
      &      SeedFrac,SHF,SLPF,SPi_AVAIL,SRAD,STGDOY,SUMDTT,SW,  !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,     !Input
      &      WEATHER,WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,       !Input
-     &      YRDOY, YRPLT, Z2STAGE,                              !Input
+     &      YRDOY, YRPLT, Z2STAGE, PAR,                         !Input
      &      EARS, GPP, MDATE,                                   !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,      !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,    !Output
@@ -705,7 +709,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT,                                     !Input
+     &      YRDOY, YRPLT, PAR,                                !Input
      &      EARS, GPP, MDATE,                                 !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -761,7 +765,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail,                          !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -783,7 +787,7 @@ C----------------------------------------------------------------------
      &      SeedFrac,SHF,SLPF,SPi_AVAIL,SRAD,STGDOY,SUMDTT,SW,  !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,     !Input
      &      WEATHER,WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,       !Input
-     &      YRDOY, YRPLT, Z2STAGE,                              !Input
+     &      YRDOY, YRPLT, Z2STAGE, PAR,                         !Input
      &      EARS, GPP, MDATE,                                   !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,      !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,    !Output
@@ -804,7 +808,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT,                                     !Input
+     &      YRDOY, YRPLT, PAR,                                !Input
      &      EARS, GPP, MDATE,                                 !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -869,7 +873,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail,                          !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -891,7 +895,7 @@ C----------------------------------------------------------------------
      &      SeedFrac,SHF,SLPF,SPi_AVAIL,SRAD,STGDOY,SUMDTT,SW,  !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,     !Input
      &      WEATHER,WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,       !Input
-     &      YRDOY, YRPLT, Z2STAGE,                              !Input
+     &      YRDOY, YRPLT, Z2STAGE, PAR,                         !Input
      &      EARS, GPP, MDATE,                                   !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,      !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,    !Output
@@ -912,7 +916,7 @@ C----------------------------------------------------------------------
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT,                                     !Input
+     &      YRDOY, YRPLT, PAR,                                !Input
      &      EARS, GPP, MDATE,                                 !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output

--- a/Plant/CERES-Maize/MZ_GROSUB.for
+++ b/Plant/CERES-Maize/MZ_GROSUB.for
@@ -46,7 +46,7 @@
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail,                          !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -1113,7 +1113,7 @@ C-GH 60     FORMAT(25X,F5.2,13X,F5.2,7X,F5.2)
           !                Daily Photosynthesis Rate
           ! ------------------------------------------------------------
           !Compare with weather module: PAR = SRAD * 2.0  chp
-          PAR = SRAD*PARSR    !PAR local variable
+          !PAR = SRAD*PARSR    !PAR local variable    no need to calculate because PAR is given as input 
 
           LIFAC  = 1.5 - 0.768 * ((ROWSPC * 0.01)**2 * PLTPOP)**0.1 
           PCO2  = TABEX (CO2Y,CO2X,CO2,10)

--- a/Plant/CERES-Maize/MZ_GROSUB.for
+++ b/Plant/CERES-Maize/MZ_GROSUB.for
@@ -46,7 +46,7 @@
      &      SHF, SLPF, SPi_AVAIL, SRAD, STGDOY, SUMDTT, SW,   !Input
      &      SWIDOT, TLNO, TMAX, TMIN, TRWUP, TSEN, VegFrac,   !Input
      &      WLIDOT, WRIDOT, WSIDOT, XNTI, XSTAGE,             !Input
-     &      YRDOY, YRPLT, SKi_Avail, PAR,                     !Input
+     &      YRDOY, YRPLT, SKi_Avail, PAR, NOPAR,              !Input
      &      EARS, GPP, MDATE,HARVFRAC,                        !I/O
      &      AGEFAC, APTNUP, AREALF, CANHT, CANNAA, CANWAA,    !Output
      &      CANWH, CARBO, GNUP, GPSM, GRNWT, GRORT, HI, HIP,  !Output
@@ -361,7 +361,10 @@
        
       TYPE (ResidueType) SENESCE 
       TYPE (SwitchType)  ISWITCH
-  
+
+!     added for using PAR from weather file
+      LOGICAL     NOPAR
+
 !----------------------------------------------------------------------
 !     CHP 3/31/2006
 !     Proportion of lignin in STOVER and Roots
@@ -1113,7 +1116,13 @@ C-GH 60     FORMAT(25X,F5.2,13X,F5.2,7X,F5.2)
           !                Daily Photosynthesis Rate
           ! ------------------------------------------------------------
           !Compare with weather module: PAR = SRAD * 2.0  chp
-          !PAR = SRAD*PARSR    !PAR local variable    no need to calculate because PAR is given as input 
+
+          !set PAR value.
+          IF (NOPAR)  THEN 
+              PAR = SRAD*PARSR    !PAR local variable, calculated here if there's no value from the weather file 
+          ELSE
+              PAR = PAR / 4.57    !PAR unit convertion from moles/m2/day (coming from weather file) to MJ/m2/day
+          ENDIF
 
           LIFAC  = 1.5 - 0.768 * ((ROWSPC * 0.01)**2 * PLTPOP)**0.1 
           PCO2  = TABEX (CO2Y,CO2X,CO2,10)

--- a/Plant/CERES-Wheat_Barley/CER_Growth.for
+++ b/Plant/CERES-Wheat_Barley/CER_Growth.for
@@ -7,7 +7,7 @@
      &     DLAYR, DOY, DUL, EO, EOP, ISWNIT, ISWWAT,
      &     KCAN, KEP, LL, NFP, NH4LEFT, NLAYR , NO3LEFT,
      &     RLV, RNMODE, SAT , SENCALG, SENNALG,
-     &     SHF, SLPF, SNOW, SRAD, ST, STGDOY, SW,
+     &     SHF, SLPF, SNOW, SRAD, ST, STGDOY, SW, PAR, NOPAR,
      &     TMAX, TMIN, TRWUP, UH2O, UNH4ALG, UNO3ALG, WEATHER,
      &     SOILPROP, CONTROL, WINDSP, YEAR,
      &     YEARPLTCSM, LAI, IDETG)
@@ -28,9 +28,10 @@
         REAL DUL(20), EO, EOP, KCAN, KEP, LL(20), NFP, NH4LEFT(20)
         REAL NO3LEFT(20), RLV(20), SAT(20)
         REAL SENCALG(0:20), SENNALG(0:20), SHF(20), SLPF
-        REAL SRAD, ST(0:20), SW(20), TMAX, TMIN, TRWUP
+        REAL SRAD, ST(0:20), SW(20), TMAX, TMIN, TRWUP, PAR
         REAL UH2O(20), WINDSP, LAI
         REAL DAYLT, RWUMX, RWUPM, SNOW, TFAC4, YVALXY
+        LOGICAL NOPAR
         
         CHARACTER*1 IDETG, ISWNIT, ISWWAT, RNMODE
         
@@ -181,7 +182,12 @@ C  FO - 05/07/2020 Add new Y4K subroutine call to convert YRDOY
         IF (YEARDOY.GE.YEARPLT) THEN   
 
           ! Photosynthetically active radiation
-          PARAD = PARADFAC*SRAD
+          ! set PAR(PARAD) value.
+          IF (NOPAR)  THEN
+              PARAD = PARADFAC*SRAD    !calculated here if there's no value from the weather file 
+          ELSE
+              PARAD = PAR / 4.57    !PAR unit convertion from moles/m2/day (coming from weather file) to MJ/m2/day
+          ENDIF
 
           ! Mean temperature
           TMEAN = (TMAX+TMIN)/2.0

--- a/Plant/CERES-Wheat_Barley/CSCER.for
+++ b/Plant/CERES-Wheat_Barley/CSCER.for
@@ -27,7 +27,7 @@
 !     SUBROUTINE CSCER (FILEIOIN, RUN, TN, RN,             !Command line
 !    & ISWWAT, ISWNIT, IDETO, IDETG, IDETL, FROP,          !Controls
 !    & SN, ON, RUNI, REP, YEAR, DOY, STEP, CN,             !Run+loop
-!    & SRAD, TMAX, TMIN, CO2, RAIN, DEWDUR,                !Weather
+!    & SRAD, TMAX, TMIN, CO2, RAIN, DEWDUR, PAR, NOPAR,    !Weather
 !    & DAYLT, WINDSP, ST, EO,                              !Weather
 !    & NLAYR, DLAYR, DEPMAX, LL, DUL, SAT, BD, SHF, SLPF,  !Soil states
 !    & SNOW, SW, NO3LEFT, NH4LEFT,                         !H2o,N states
@@ -45,7 +45,7 @@
       SUBROUTINE CSCER (FILEIOIN, RUN, TN, RN, RNMODE,     !Command line
      & ISWWAT, ISWNIT, IDETS, IDETO, IDETG, IDETL, FROP,   !Controls
      & SN, ON, RUNI, REP, YEAR, DOY, STEP, CN,             !Run+loop
-     & SRAD, TMAX, TMIN, CO2, RAIN, TOTIR,                 !Weather
+     & SRAD, TMAX, TMIN, CO2, RAIN, TOTIR, PAR, NOPAR,     !Weather
      & DAYLT, WINDSP, ST, EO,                              !Weather
      & NLAYR, DLAYR, DEPMAX, LL, DUL, SAT, BD, SHF, SLPF,  !Soil states
      & SNOW, SW, NO3LEFT, NH4LEFT,                         !H2o,N states
@@ -197,8 +197,9 @@
       REAL RAIN, RWUPM, RWUMX, SLPF, SHF(NL)
       REAL ST(0:NL), SENNALG(0:NL), SENCALG(0:NL), TRWUP, UH2O(NL)
       REAL SW(20), NO3LEFT(20), NH4LEFT(NL)
-      REAL CO2, TMAX, TMIN, SRAD, WINDSP, SNOW
+      REAL CO2, TMAX, TMIN, SRAD, WINDSP, SNOW, PAR
       REAL TFAC4, TOTIR, YVALXY, YVAL1
+      LOGICAL NOPAR
 
       CHARACTER*1   IDETG, ISWNIT, ISWWAT, IDETL, IDETO, IDETS
       CHARACTER*1   RNMODE
@@ -225,7 +226,7 @@
      &     DLAYR, DOY, DUL, EO, EOP, ISWNIT, ISWWAT,
      &     KCAN, KEP, LL, NFP, NH4LEFT, NLAYR , NO3LEFT,
      &     RLV, RNMODE, SAT , SENCALG, SENNALG,
-     &     SHF, SLPF, SNOW, SRAD, ST, STGDOY, SW,
+     &     SHF, SLPF, SNOW, SRAD, ST, STGDOY, SW, PAR, NOPAR,
      &     TMAX, TMIN, TRWUP, UH2O, UNH4ALG, UNO3ALG, WEATHER,
      &     SOILPROP, CONTROL, WINDSP, YEAR,
      &     YEARPLTCSM, LAI, IDETG)

--- a/Plant/CERES-Wheat_Barley/CSCERES_Interface.for
+++ b/Plant/CERES-Wheat_Barley/CSCERES_Interface.for
@@ -32,11 +32,12 @@ C=======================================================================
       INTEGER MULTI, FROP, SN, YEAR, DOY
       INTEGER STGDOY(20), YRPLT
 
-      REAL WUPT, EOP, EP, ET, TRWUP, SRAD, TMAX, TMIN, CO2
+      REAL WUPT, EOP, EP, ET, TRWUP, SRAD, TMAX, TMIN, CO2, PAR
       REAL SNOW, KCAN, KEP, DEPMAX
       REAL NSTRES, XLAI, LAI, NFP, SLPF
       REAL DAYL, TWILEN, PORMIN, RAIN, RWUMX, SRFTEMP
       REAL CANHT, EO, TOTIR, WINDSP
+      LOGICAL NOPAR
 
       REAL, DIMENSION(NL) :: BD, DLAYR, DS, DUL, LL
       REAL, DIMENSION(NL) :: NH4, NO3, RLV, SAT, SHF
@@ -118,16 +119,18 @@ C=======================================================================
       DAYL  = WEATHER % DAYL 
       RAIN  = WEATHER % RAIN
       SRAD  = WEATHER % SRAD
+      PAR   = WEATHER % PAR
       TMAX  = WEATHER % TMAX
       TMIN  = WEATHER % TMIN
       TWILEN= WEATHER % TWILEN
       WINDSP= WEATHER % WINDSP
+      NOPAR = WEATHER % NOPAR
 
 C-----------------------------------------------------------------------
       CALL CSCER (FILEIOCS, RUN, TN, RN, RNMODE,           !Command line
      & ISWWAT, ISWNIT, IDETS, IDETO, IDETG, IDETL, FROP,   !Controls
      & SN, ON, RUNI, REP, YEAR, DOY, STEP, CN,             !Run+loop
-     & SRAD, TMAX, TMIN, CO2, RAIN, TOTIR,                 !Weather
+     & SRAD, TMAX, TMIN, CO2, RAIN, TOTIR, PAR, NOPAR,     !Weather
      & TWILEN, WINDSP, SOILTEMP, EO,                       !Weather
      & NLAYR, DLAYR, DEPMAX, LL, DUL, SAT, BD, SHF, SLPF,  !Soil states
      & SNOW, SW, NO3, NH4,                                 !H2o,N states

--- a/Utilities/ModuleDefs.for
+++ b/Utilities/ModuleDefs.for
@@ -144,7 +144,7 @@ C             CHP Added TRTNUM to CONTROL variable.
      &    SRAD, TAMP, TA, TAV, TAVG, TDAY, TDEW, TGROAV, TGRODY,      
      &    TMAX, TMIN, TWILEN, VAPR, WINDRUN, WINDSP, VPDF, VPD_TRANSP,
      &    OZON7
-        LOGICAL NOTDEW, NOWIND
+        LOGICAL NOTDEW, NOWIND, NOPAR
 
 !       Hourly weather data
         REAL, DIMENSION(TS) :: AMTRH, AZZON, BETA, FRDIFP, FRDIFR, PARHR

--- a/Weather/weathr.for
+++ b/Weather/weathr.for
@@ -71,7 +71,7 @@ C=======================================================================
      &  TA, TAMP, TAV, TAVG, TDAY, TDEW, TGROAV, TGRODY,
      &  TMAX, TMIN, TWILEN, VAPR, WINDHT, WINDRUN, WINDSP,
      &  XELEV, XLAT, XLONG
-      LOGICAL NOTDEW, NOWIND
+      LOGICAL NOTDEW, NOWIND, NOPAR
       REAL CALC_TDEW
 
       REAL, DIMENSION(TS) :: AMTRH, AZZON, BETA, FRDIFP, FRDIFR, PARHR
@@ -223,7 +223,7 @@ C         message to the WARNING.OUT file.
      &   ('Value of TAV, average annual soil temperature, is missing.')
   110 FORMAT('Value of TAMP, amplitude of soil temperature function,',
      &            ' is missing.')
-  120 FORMAT('A default value of', F5.1, 'ºC is being used for this',
+  120 FORMAT('A default value of', F5.1, 'ï¿½C is being used for this',
      &            ' simulation,')
   130 FORMAT('which may produce undesirable results.')
 
@@ -287,6 +287,13 @@ c                   available.
           ENDIF
       ELSE
           NOTDEW = .FALSE.
+      ENDIF
+
+!     Set NOPAR to true if PAR is missing.
+      IF (PAR <= -90.)  THEN 
+          NOPAR = .TRUE.
+      ELSE
+          NOPAR = .FALSE.
       ENDIF
 
 C     Calculate hourly weather data.
@@ -422,7 +429,14 @@ c                   available.
       ELSE
           NOTDEW = .FALSE.
       ENDIF      
-      
+
+!     Set NOPAR to true if PAR is missing.
+      IF (PAR <= -90.)  THEN 
+          NOPAR = .TRUE.
+      ELSE
+          NOPAR = .FALSE.
+      ENDIF
+
 C     Calculate hourly weather data.
       CALL HMET(
      &    CLOUDS, DAYL, DEC, ISINB, PAR, REFHT,           !Input
@@ -497,6 +511,7 @@ C-----------------------------------------------------------------------
       WEATHER % DAYL   = DAYL
       WEATHER % NOTDEW = NOTDEW
       WEATHER % NOWIND = NOWIND
+      WEATHER % NOPAR  = NOPAR
       WEATHER % OZON7  = OZON7  
       WEATHER % PAR    = PAR   
       WEATHER % RAIN   = RAIN  
@@ -564,6 +579,7 @@ C-----------------------------------------------------------------------
 ! NEV        Number of environmental modification records 
 ! NOTDEW     No TDEW read from weather file
 ! NOWIND     No WIND read from weather file
+! NOPAR      No PAR read from weather file
 ! RUN        Report number for sequenced or multi-season runs 
 ! PAR        Daily photosynthetically active radiation or photon flux 
 !              density (moles[quanta]/m2-d)
@@ -581,19 +597,19 @@ C-----------------------------------------------------------------------
 ! SNDN       Time of sunset (hr)
 ! SNUP       Time of sunrise (hr)
 ! SRAD       Solar radiation (MJ/m2-d)
-! TAIRHR(TS) Hourly air temperature (in some routines called TGRO) (°C)
+! TAIRHR(TS) Hourly air temperature (in some routines called TGRO) (ï¿½C)
 ! TAMP       Amplitude of temperature function used to calculate soil 
-!              temperatures (°C)
+!              temperatures (ï¿½C)
 ! TAV        Average annual soil temperature, used with TAMP to calculate 
-!              soil temperature. (°C)
-! TAVG       Average daily temperature (°C)
-! TDAY       Average temperature during daylight hours (°C)
-! TDEW       Dewpoint temperature (°C)
-! TGRO(I)    Hourly air temperature (°C)
-! TGROAV     Average daily canopy temperature (°C)
-! TGRODY     Average temperature during daylight hours (°C)
-! TMAX       Maximum daily temperature (°C)
-! TMIN       Minimum daily temperature (°C)
+!              soil temperature. (ï¿½C)
+! TAVG       Average daily temperature (ï¿½C)
+! TDAY       Average temperature during daylight hours (ï¿½C)
+! TDEW       Dewpoint temperature (ï¿½C)
+! TGRO(I)    Hourly air temperature (ï¿½C)
+! TGROAV     Average daily canopy temperature (ï¿½C)
+! TGRODY     Average temperature during daylight hours (ï¿½C)
+! TMAX       Maximum daily temperature (ï¿½C)
+! TMIN       Minimum daily temperature (ï¿½C)
 ! TS         Number of intermediate time steps per day (usually 24)
 !                    set = 240 on 9JAN17 by Bruce Kimball      
 ! WINDHR(TS) Hourly wind speed (m/s)


### PR DESCRIPTION
previously in Maize and Wheat & barley models PAR was calculated from full radiation (SRAD) value, so the models were indifferent to the PAR value in the weather files. This addition to the code enables those models to use PAR value from the weather file if provided, and keep doing the same calculation as before if not provided. 