### PR TITLE
Fix divide by zero for SWI

### DIFF
--- a/Soil/Inorganic_N/OXLAYER.for
+++ b/Soil/Inorganic_N/OXLAYER.for
@@ -199,7 +199,7 @@ C=======================================================================
 
       STI = AMIN1 (STI,1.0)
       SWI = 1.0
-      IF (SW(1) .LT. DUL(1)) THEN
+      IF (SW(1) .LT. DUL(1) .AND. SAT(1) .GT. SW(1)) THEN
          SWI = (SAT(1)-DUL(1))/(SAT(1)-SW(1))
       ENDIF
 


### PR DESCRIPTION
There is an equality check for SW(1) and SAT(1) on line 188, but there is no equality check on line 202. We have run into instances where SAT(1) == SW(1) and the model crashes. This patches it (and verifies the denominator is positive).