### PR TITLE
Fixed bug in reading ASCE ET input parameters from species

### DIFF
--- a/Plant/plant.for
+++ b/Plant/plant.for
@@ -936,6 +936,7 @@ c     Total LAI must exceed or be equal to healthy LAI:
 !-----------------------------------------------------------------------
       FILEIO = CONTROL % FILEIO
       LUNIO  = CONTROL % LUNIO
+      CROP   = CONTROL % CROP
       OPEN (LUNIO, FILE = FILEIO, STATUS = 'OLD', IOSTAT=ERR)
       IF (ERR .NE. 0) CALL ERROR(ERRKEY,ERR,FILEIO,0)
       READ(LUNIO,50,IOSTAT=ERR) FILEC, PATHCR ; LNUM = 7


### PR DESCRIPTION
Needed this line of code to get ASCE ET working properly for a sequence simulation.