### PR TITLE
Removed the routine "SYSTEM" as EXTERNAL inside UTILS.for

### DIFF
--- a/Utilities/UTILS.for
+++ b/Utilities/UTILS.for
@@ -977,7 +977,7 @@ C=======================================================================
 C        USE IFPORT
 !cDEC$ ENDIF
       IMPLICIT NONE
-      EXTERNAL GETLUN, OUTFILES, WARNING, SYSTEM
+      EXTERNAL GETLUN, OUTFILES, WARNING
 !     Can't list routine SYSTEM as external because it generates an
 !       error with some compilers.
 
@@ -1064,7 +1064,7 @@ C=======================================================================
 C        USE IFPORT
 !!!!cDEC$ ENDIF
       IMPLICIT NONE
-      EXTERNAL GETLUN, SYSTEM
+      EXTERNAL GETLUN
 
       SAVE
       INTEGER i, COUNT, LUNLST, LUNTMP, SYS, SYSTEM


### PR DESCRIPTION
Can't list routine SYSTEM as external because it generates an error with some compilers.