### PR TITLE
Potential soil evaporation adjusted too much for mulch evap

### DIFF
--- a/SPAM/SPAM.for
+++ b/SPAM/SPAM.for
@@ -337,12 +337,13 @@ C=======================================================================
 !         Next meet evaporative demand from mulch
           IF (EOS_SOIL > 1.E-6 .AND. INDEX('RSM',MEINF) > 0) THEN
             CALL MULCH_EVAP(DYNAMIC, MULCH, EOS_SOIL, EM)
-            IF (EOS_SOIL > EM) THEN
-!             Some evaporative demand leftover for soil
-              EOS_SOIL = EOS_SOIL - EM
-            ELSE
-              EOS_SOIL = 0.0
-            ENDIF
+!            chp 2025-03-13 EOS_SOIL has already been reduced based on mulch evap. 
+!            IF (EOS_SOIL > EM) THEN
+!!             Some evaporative demand leftover for soil
+!              EOS_SOIL = EOS_SOIL - EM
+!            ELSE
+!              EOS_SOIL = 0.0
+!            ENDIF
           ENDIF
 
 !         Soil evaporation after flood and mulch evaporation


### PR DESCRIPTION
While working on the modified Suleiman-Ritchie model, I came across a bug in SPAM. Mulch evaporation is accounted for twice and reduces soil evaporation too much. This commit fixes the problem. It does have an impact on some experiments:

- lentil - biggest effect of any crop -7.5% CWAM, -8.4% HWAM, 2 days MDAT for one trt
- chia - 2 days MDAT but <2% CWAM and HWAM
- cowpea - 1 day MDAT but negligable effect on other variables.
- soybean - one trt with -2.7% HWAM, 1 day MDAT
- Sunflower - big diffs but these reflect the debug vs release and other differences that we have not yet tracked down.
- Safflower - -2 days MDAT, -3.8% HWAM

It is a bug, but minor. We should probably fix it but need to thoroughly assess impact.

