### PR TITLE
Cscas hotfix

### DIFF
--- a/InputModule/OPHEAD.for
+++ b/InputModule/OPHEAD.for
@@ -1046,7 +1046,7 @@ C========================================================================
       INTEGER ShortCount
 
       DATA PREV_RUN /0/
-      INTEGER, PARAMETER :: MAXLUN = 200
+      INTEGER, PARAMETER :: MAXLUN = 1000
       logical NOHEADER(MAXLUN)
 
       TYPE (ControlType) CONTROL

--- a/Plant/CSCAS/CSCAS.for
+++ b/Plant/CSCAS/CSCAS.for
@@ -318,6 +318,7 @@
       INTEGER       EVHEADNMMAX   ! Maximum no headings in ev file #
       INTEGER       EYEARDOY      ! Emergence Year+DOY             #
       REAL          FAC(20)       ! Factor ((g/Mg)/(kg/ha))        #
+      REAL          FACTOR        ! Factor chp 2025-10-24
       INTEGER       FAPPNUM       ! Fertilization application number
       INTEGER       FDAY(200)     ! Dates of fertilizer appn       YrDoy
       REAL          FERNIT        ! Fertilizer N applied           kg/ha
@@ -4357,9 +4358,15 @@ C-GH As per Tony Hunt 2017 for GenCalc
                 DUPNEXT = 0.0
               ELSE  
                 DUPHASE = DUNEED
-                TIMENEED = DUNEED/
-     &           (TT*(DFPE*(GERMFR-EMRGFR)+DF*EMRGFR))
-                DUPNEXT = TTNEXT*(1.0-TIMENEED)*DFNEXT
+!               2025-10-24 CHP Prevent zero-divide
+                IF (TT*(DFPE*(GERMFR-EMRGFR)+DF*EMRGFR) > 0.0) THEN
+                  TIMENEED = DUNEED/
+     &             (TT*(DFPE*(GERMFR-EMRGFR)+DF*EMRGFR))
+                  DUPNEXT = TTNEXT*(1.0-TIMENEED)*DFNEXT
+                ELSE
+                  TIMENEED = 1.0
+                  DUPNEXT = 0.0
+                ENDIF
               ENDIF
             ELSE
             ENDIF
@@ -5270,18 +5277,36 @@ C-GH As per Tony Hunt 2017 for GenCalc
               ! For supplying minimum
               NDEMMN = GROLF*LNCM+RTWTG*RNCM
      &              +(GROST+GROCR)*SNCM+GROSR*(SRNPCS/100.0)*0.5
-              LNUSE(1) = (GROLF*LNCM)*AMIN1(1.0,NULEFT/NDEMMN)
-              RNUSE(1) = (RTWTG*RNCM)*AMIN1(1.0,NULEFT/NDEMMN)
-              SNUSE(1) = 
-     &         ((GROST+GROCR)*SNCM)*AMIN1(1.0,NULEFT/NDEMMN)
-              SRNUSE(1) = 
-     &           (GROSR*(SRNPCS/100.0)*0.5)*AMIN1(1.0,NULEFT/NDEMMN)
+
+!             2025-10-24 CHP Prevent zero-divide
+!             LNUSE(1) = (GROLF*LNCM)*AMIN1(1.0,NULEFT/NDEMMN)
+!             RNUSE(1) = (RTWTG*RNCM)*AMIN1(1.0,NULEFT/NDEMMN)
+!             SNUSE(1) = 
+!    &         ((GROST+GROCR)*SNCM)*AMIN1(1.0,NULEFT/NDEMMN)
+!             SRNUSE(1) = 
+!    &           (GROSR*(SRNPCS/100.0)*0.5)*AMIN1(1.0,NULEFT/NDEMMN)
+
+              IF (NDEMMN .LE. 0) THEN
+                FACTOR = 1.0
+              ELSE
+                FACTOR = AMIN1(1.0,NULEFT/NDEMMN)
+              ENDIF
+
+              LNUSE(1) = (GROLF*LNCM) * FACTOR
+              RNUSE(1) = (RTWTG*RNCM) * FACTOR
+              SNUSE(1) = ((GROST+GROCR)*SNCM) * FACTOR
+              SRNUSE(1) = (GROSR*(SRNPCS/100.0)*0.5) * FACTOR
 
               ! Reduce stem,crown,root growth if N < supply minimum
               IF (NDEMMN.GT.NULEFT) THEN
-                GROSTADJ = GROST*AMIN1(1.0,NULEFT/NDEMMN)
-                GROCRADJ = GROCR*AMIN1(1.0,NULEFT/NDEMMN)
-                RTWTGADJ = RTWTG*AMIN1(1.0,NULEFT/NDEMMN)
+!               2025-10-24 CHP Prevent zero-divide
+!               GROCRADJ = GROCR*AMIN1(1.0,NULEFT/NDEMMN)
+!               RTWTGADJ = RTWTG*AMIN1(1.0,NULEFT/NDEMMN)
+!               GROSTADJ = GROST*AMIN1(1.0,NULEFT/NDEMMN)
+
+                GROSTADJ = GROST * FACTOR
+                GROCRADJ = GROCR * FACTOR
+                RTWTGADJ = RTWTG * FACTOR
                 RTRESPADJ = RTWTGADJ*RRESP/(1.0-RRESP)   
               ELSE
                 GROSTADJ = GROST

--- a/Soil/SoilUtilities/SOILDYN.for
+++ b/Soil/SoilUtilities/SOILDYN.for
@@ -1808,7 +1808,8 @@ c** wdb orig          SUMKEL = SUMKE * EXP(-0.15*MCUMDEP)
       IF (DYNAMIC .EQ. SEASINIT) THEN
 !-----------------------------------------------------------------------
       IF (INDEX('AD',ISWITCH % IDETL) > 0 .AND. ISWITCH % IDETW == 'Y' 
-     &   .AND.  INDEX('YR',ISWITCH % ISWTIL) > 0) THEN
+!    &   .AND.  INDEX('YR',ISWITCH % ISWTIL) > 0) THEN
+     &    ) THEN
         PrintDyn = .TRUE. 
         CALL GETLUN('OUTSOL',DLUN)
 !       Temporary output file for debugging:
@@ -1825,7 +1826,7 @@ c** wdb orig          SUMKEL = SUMKE * EXP(-0.15*MCUMDEP)
        IF (INDEX('FQ',CONTROL%RNMODE) > 0 .AND. CONTROL%RUN /= 1)RETURN
         CALL HEADER(SEASINIT, DLUN, CONTROL % RUN)
         WRITE(DLUN,"(/,
-     &     '@YEAR DOY   DAS   CRAIN  SOLCOV   SUMKE    ROCN   TOTAW',
+     &  '@YEAR DOY   DAS   CRAIN  SOLCOV   SUMKE    ROCN   TOTAW',
      &  '  KECHG1  KECHG2  KECHG3  KECHG4',
      &  '  DLAYR1  DLAYR2  DLAYR3  DLAYR4',
      &  '     BD1     BD2     BD3     BD4',
@@ -1833,7 +1834,8 @@ c** wdb orig          SUMKEL = SUMKE * EXP(-0.15*MCUMDEP)
      &  '   SWCN1   SWCN2   SWCN3   SWCN4',
      &  '    SAT1    SAT2    SAT3    SAT4',
      &  '    DUL1    DUL2    DUL3    DUL4',
-     &  '     LL1     LL2     LL3     LL4')")
+     &  '     LL1     LL2     LL3     LL4',
+     &  '    DML1    DML2    DML3    DML4')")
       ELSE
         PrintDyn = .FALSE.
       ENDIF
@@ -1851,7 +1853,7 @@ c** wdb orig          SUMKEL = SUMKE * EXP(-0.15*MCUMDEP)
         CALL YR_DOY(CONTROL % YRDOY, YEAR, DOY) 
         WRITE(DLUN,'(1X,I4,1X,I3.3,1X,I5,
      &    F8.1,2F8.3,F8.1,F8.2,
-     &    4F8.3,4F8.2,8F8.3,4F8.3,4F8.2,8F8.5)') 
+     &    4F8.3,4F8.2,8F8.3,4F8.3,4F8.2,12F8.5)') 
      &    YEAR, DOY, CONTROL % DAS, CRAIN, SOILCOV, SUMKE, CN, TOTAW, 
      &    KECHGE(1),KECHGE(2),KECHGE(3),KECHGE(4),
      &    DLAYR (1), DLAYR(2), DLAYR(3), DLAYR(4),
@@ -1860,7 +1862,8 @@ c** wdb orig          SUMKEL = SUMKE * EXP(-0.15*MCUMDEP)
      &    SWCN  (1),  SWCN(2),  SWCN(3),  SWCN(4),
      &    SAT   (1),   SAT(2),   SAT(3),   SAT(4),
      &    DUL   (1),   DUL(2),   DUL(3),   DUL(4),
-     &    LL    (1),    LL(2),    LL(3),    LL(4)
+     &    LL    (1),    LL(2),    LL(3),    LL(4),
+     &    DUL(1)-LL(1), DUL(2)-LL(2), DUL(3)-LL(3), DUL(4)-LL(4)
         Print_today =  .FALSE.
       ENDIF
 


### PR DESCRIPTION
These changes fix a couple of zero divides in CSCAS model. The problem occurred in the NUS spatial simulations of cassava in the highlands of Laos and Thailand and *may* be environmentally related. 

It would be good for @lpmorenoc and/or @thiagoferreira53 to take a good look at these changes. 

I have not compared effects for all cassava DSSAT simulations, but I wanted to note the bugfix here and alert others to the issue. For the NUS simulations that ran to completion prior to the bugfix, these changes did not affect any model outputs, so I think it is low risk.

This is low priority since no one else has reported any issues. I have already supplied NUS with a revised executable with these changes.

This pull request also includes some minor changes affecting the SoilDyn.OUT file that I had in the code for comparison with another model version. It should not affect anything else and is OK to include in the model if this pull request is accepted.