### PR TITLE
Updated the code to prevent using default ecotype coefficients when the ecotype ID is missing

### DIFF
--- a/Data/MODEL.ERR
+++ b/Data/MODEL.ERR
@@ -244,6 +244,9 @@ DEFAULT Ecotype not found. Fix ecotype input file.
 IPECO     4
 Missing ecotype coefficients. Fix ecotype input file.
 
+IPECO     5
+Ecotype ID (ECONAME) not found. Fix ecotype input file.
+
 IPECO    21
 Ecotype input section not found.  Please correct file.
 

--- a/InputModule/IPECO.for
+++ b/InputModule/IPECO.for
@@ -154,10 +154,13 @@ C
 
  3200 CONTINUE
       IF (ECONO .EQ. 'DFAULT') CALL ERROR (ERRKEY,3,FILEE,LINECO)
-      ECONO = 'DFAULT'
-      REWIND (LUNECO)
-      I = 0
-      GO TO 2010
+      ! TF (01/16/2026) - Replaced the default ecotype handling with
+      ! an error call to avoid the use of unexisting ecotype IDs.
+      CALL ERROR("IPECO",4,FILEE,1)
+      !ECONO = 'DFAULT'
+      !REWIND (LUNECO)
+      !I = 0
+      !GO TO 2010
 
 C-----------------------------------------------------------------------
 C     Format Strings

--- a/Plant/CROPGRO/CANOPY.for
+++ b/Plant/CROPGRO/CANOPY.for
@@ -151,10 +151,13 @@ C-----------------------------------------------------------------------
           ENDIF
 
         ELSE IF (ISECT .EQ. 0) THEN
-          IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
-          ECONO = 'DFAULT'
-          REWIND(LUNECO)
-          LNUM = 0
+!         TF (01/16/2026) - Replaced the default ecotype handling with
+!         an error call to avoid the use of unexisting ecotype IDs.
+          CALL ERROR("IPECO",21,FILEGC,1)
+          !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
+          !ECONO = 'DFAULT'
+          !REWIND(LUNECO)
+          !LNUM = 0
         ENDIF
       ENDDO
 

--- a/Plant/CROPGRO/CANOPY.for
+++ b/Plant/CROPGRO/CANOPY.for
@@ -153,7 +153,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !         TF (01/16/2026) - Replaced the default ecotype handling with
 !         an error call to avoid the use of unexisting ecotype IDs.
-          CALL ERROR("IPECO",21,FILEGC,1)
+          CALL ERROR("IPECO",5,FILEGC,1)
           !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
           !ECONO = 'DFAULT'
           !REWIND(LUNECO)

--- a/Plant/CROPGRO/DEMAND.for
+++ b/Plant/CROPGRO/DEMAND.for
@@ -986,7 +986,7 @@ C 24 changed to TS by Bruce Kimball on 3Jul17
         ELSE IF (ISECT .EQ. 0) THEN
 !         TF (01/16/2026) - Replaced the default ecotype handling with
 !         an error call to avoid the use of unexisting ecotype IDs.
-          CALL ERROR("IPECO",21,FILEGC,1)
+          CALL ERROR("IPECO",5,FILEGC,1)
           
           !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
           !ECONO = 'DFAULT'

--- a/Plant/CROPGRO/DEMAND.for
+++ b/Plant/CROPGRO/DEMAND.for
@@ -984,10 +984,14 @@ C 24 changed to TS by Bruce Kimball on 3Jul17
           ENDIF
 
         ELSE IF (ISECT .EQ. 0) THEN
-          IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
-          ECONO = 'DFAULT'
-          REWIND(LUNECO)
-          LNUM = 0
+!         TF (01/16/2026) - Replaced the default ecotype handling with
+!         an error call to avoid the use of unexisting ecotype IDs.
+          CALL ERROR("IPECO",21,FILEGC,1)
+          
+          !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
+          !ECONO = 'DFAULT'
+          !REWIND(LUNECO)
+          !LNUM = 0
         ENDIF
       ENDDO
 

--- a/Plant/CROPGRO/Ipphenol.for
+++ b/Plant/CROPGRO/Ipphenol.for
@@ -223,10 +223,15 @@ C-----------------------------------------------------------------------
             ENDIF
 
           ELSE IF (ISECT .EQ. 0) THEN
-            IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
-            ECONO = 'DFAULT'
-            REWIND(LUNECO)
-            LNUM = 0
+          
+!         TF (01/16/2026) - Replaced the default ecotype handling with
+!         an error call to avoid the use of unexisting ecotype IDs.
+          CALL ERROR("IPECO",21,FILEGC,1)
+          
+            !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
+            !ECONO = 'DFAULT'
+            !REWIND(LUNECO)
+            !LNUM = 0
           ENDIF
         ENDDO
 

--- a/Plant/CROPGRO/Ipphenol.for
+++ b/Plant/CROPGRO/Ipphenol.for
@@ -226,7 +226,7 @@ C-----------------------------------------------------------------------
           
 !         TF (01/16/2026) - Replaced the default ecotype handling with
 !         an error call to avoid the use of unexisting ecotype IDs.
-          CALL ERROR("IPECO",21,FILEGC,1)
+          CALL ERROR("IPECO",5,FILEGC,1)
           
             !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
             !ECONO = 'DFAULT'

--- a/Plant/CROPGRO/LTGROW.for
+++ b/Plant/CROPGRO/LTGROW.for
@@ -67,7 +67,7 @@ C-----------------------------------------------------------------------
             ELSE IF (ISECT .EQ. 0) THEN
 !           TF (01/16/2026) - Replaced the default ecotype handling with
 !           an error call to avoid the use of unexisting ecotype IDs.
-            CALL ERROR("IPECO",21,FILEGC,1)
+            CALL ERROR("IPECO",5,FILEGC,1)
             !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
             !ECONO = 'DFAULT'
             !REWIND(LUNECO)

--- a/Plant/CROPGRO/LTGROW.for
+++ b/Plant/CROPGRO/LTGROW.for
@@ -65,10 +65,13 @@ C-----------------------------------------------------------------------
             IF (ECOTYP .EQ. ECONO) EXIT
 
             ELSE IF (ISECT .EQ. 0) THEN
-            IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
-            ECONO = 'DFAULT'
-            REWIND(LUNECO)
-            LNUM = 0
+!           TF (01/16/2026) - Replaced the default ecotype handling with
+!           an error call to avoid the use of unexisting ecotype IDs.
+            CALL ERROR("IPECO",21,FILEGC,1)
+            !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
+            !ECONO = 'DFAULT'
+            !REWIND(LUNECO)
+            !LNUM = 0
             ENDIF
         ENDDO
 

--- a/Plant/CROPGRO/PODS.for
+++ b/Plant/CROPGRO/PODS.for
@@ -264,10 +264,13 @@
           ENDIF
 
         ELSE IF (ISECT .EQ. 0) THEN
-          IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
-          ECONO = 'DFAULT'
-          REWIND(LUNECO)
-          LNUM = 0
+!         TF (01/16/2026) - Replaced the default ecotype handling with
+!         an error call to avoid the use of unexisting ecotype IDs.
+          CALL ERROR("IPECO",21,FILEGC,1)
+          !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
+          !ECONO = 'DFAULT'
+          !REWIND(LUNECO)
+          !LNUM = 0
         ENDIF
       ENDDO
 

--- a/Plant/CROPGRO/PODS.for
+++ b/Plant/CROPGRO/PODS.for
@@ -266,7 +266,7 @@
         ELSE IF (ISECT .EQ. 0) THEN
 !         TF (01/16/2026) - Replaced the default ecotype handling with
 !         an error call to avoid the use of unexisting ecotype IDs.
-          CALL ERROR("IPECO",21,FILEGC,1)
+          CALL ERROR("IPECO",5,FILEGC,1)
           !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,35,FILEGC,LNUM)
           !ECONO = 'DFAULT'
           !REWIND(LUNECO)

--- a/Plant/FORAGE/for_canopy.for
+++ b/Plant/FORAGE/for_canopy.for
@@ -166,7 +166,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !       TF (01/16/2026) - Replaced the default ecotype handling with
 !       an error call to avoid the use of unexisting ecotype IDs.
-        CALL ERROR("IPECO",21,FILEGC,1)
+        CALL ERROR("IPECO",5,FILEGC,1)
         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
         !ECONO = 'DFAULT'
         !REWIND(LUNECO)

--- a/Plant/FORAGE/for_canopy.for
+++ b/Plant/FORAGE/for_canopy.for
@@ -164,9 +164,12 @@ C-----------------------------------------------------------------------
         EXIT
         ENDIF
         ELSE IF (ISECT .EQ. 0) THEN
-        IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-        ECONO = 'DFAULT'
-        REWIND(LUNECO)
+!       TF (01/16/2026) - Replaced the default ecotype handling with
+!       an error call to avoid the use of unexisting ecotype IDs.
+        CALL ERROR("IPECO",21,FILEGC,1)
+        !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+        !ECONO = 'DFAULT'
+        !REWIND(LUNECO)
         ENDIF
       ENDDO
 
@@ -294,7 +297,7 @@ C       width.
 ! RWIDTH  Relative width of this ecotype in comparison to the standard
 !           width per node (YVSWH) defined in the species file (m)
 ! TABEX   Function subroutine - Lookup utility
-! TGRO(I) Hourly air temperature (°C)
+! TGRO(I) Hourly air temperature (ï¿½C)
 ! TURFAC  Water stress factor for expansion (0-1)
 ! VSTAGE  Number of nodes on main stem of plant
 ! WPAR    Effect of PAR on canopy width
@@ -302,7 +305,7 @@ C       width.
 !           growth rate, particularily to allow etiliolation at low
 !           PAR values (moles[quanta]/m2-d)
 ! XHWTEM  Temperatures in a table look-up function for modifying height
-!           and width growth rates (°C)
+!           and width growth rates (ï¿½C)
 ! XLAI    Leaf area (one side) per unit of ground area (m2/m2)
 ! XVSHT   Node number on main stem for use in computing height and width
 !           growth rates

--- a/Plant/FORAGE/for_demand.for
+++ b/Plant/FORAGE/for_demand.for
@@ -277,7 +277,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !         TF (01/16/2026) - Replaced the default ecotype handling with
 !         an error call to avoid the use of unexisting ecotype IDs.
-          CALL ERROR("IPECO",21,FILEGC,1)
+          CALL ERROR("IPECO",5,FILEGC,1)
          !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
          !ECONO = 'DFAULT'
          !REWIND(LUNECO)
@@ -1306,7 +1306,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !       TF (01/16/2026) - Replaced the default ecotype handling with
 !       an error call to avoid the use of unexisting ecotype IDs.
-        CALL ERROR("IPECO",21,FILEGC,1)
+        CALL ERROR("IPECO",5,FILEGC,1)
         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
         !ECONO = 'DFAULT'
         !REWIND(LUNECO)

--- a/Plant/FORAGE/for_demand.for
+++ b/Plant/FORAGE/for_demand.for
@@ -275,9 +275,12 @@ C-----------------------------------------------------------------------
         IF (ECOTYP .EQ. ECONO) EXIT
         
         ELSE IF (ISECT .EQ. 0) THEN
-         IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-         ECONO = 'DFAULT'
-         REWIND(LUNECO)
+!         TF (01/16/2026) - Replaced the default ecotype handling with
+!         an error call to avoid the use of unexisting ecotype IDs.
+          CALL ERROR("IPECO",21,FILEGC,1)
+         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+         !ECONO = 'DFAULT'
+         !REWIND(LUNECO)
         ENDIF
       ENDDO
 
@@ -1301,9 +1304,12 @@ C-----------------------------------------------------------------------
         EXIT
         ENDIF
         ELSE IF (ISECT .EQ. 0) THEN
-        IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-        ECONO = 'DFAULT'
-        REWIND(LUNECO)
+!       TF (01/16/2026) - Replaced the default ecotype handling with
+!       an error call to avoid the use of unexisting ecotype IDs.
+        CALL ERROR("IPECO",21,FILEGC,1)
+        !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+        !ECONO = 'DFAULT'
+        !REWIND(LUNECO)
         ENDIF
       ENDDO
 

--- a/Plant/FORAGE/for_dormancy.for
+++ b/Plant/FORAGE/for_dormancy.for
@@ -165,7 +165,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !       TF (01/16/2026) - Replaced the default ecotype handling with
 !       an error call to avoid the use of unexisting ecotype IDs.
-        CALL ERROR("IPECO",21,FILEGC,1)
+        CALL ERROR("IPECO",5,FILEGC,1)
         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
         !ECONO = 'DFAULT'
         !REWIND(LUNECO)

--- a/Plant/FORAGE/for_dormancy.for
+++ b/Plant/FORAGE/for_dormancy.for
@@ -163,9 +163,12 @@ C-----------------------------------------------------------------------
         EXIT
         ENDIF
         ELSE IF (ISECT .EQ. 0) THEN
-        IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-        ECONO = 'DFAULT'
-        REWIND(LUNECO)
+!       TF (01/16/2026) - Replaced the default ecotype handling with
+!       an error call to avoid the use of unexisting ecotype IDs.
+        CALL ERROR("IPECO",21,FILEGC,1)
+        !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+        !ECONO = 'DFAULT'
+        !REWIND(LUNECO)
         ENDIF
       ENDDO
         CLOSE (LUNECO)
@@ -447,7 +450,7 @@ C-----------------------------------------------------------------------
 ! FNPTD(3)  Shortest daylength threshold where there is no dormancy effect
 !              for daylength effect on partitioning (for short-day dormancy)
 ! FNPTD(4)  Minimum relative effect of dormancy when crop is non-dormant (set to 0.0)
-! FREEZ2    Temperature below which plant growth stops completely. (°C)
+! FREEZ2    Temperature below which plant growth stops completely. (ï¿½C)
 ! FRZDC        Freezing death coefficient  - percentage tissue/population death per day per degree below FREEZ2)
 ! FRZDHD(1) Minimum temperature at which dehardening begins (relative rate=0)
 ! FRZDHD(2) Temperature at which dehardening reaches maximum rate (relative rate=1)

--- a/Plant/FORAGE/for_grow.for
+++ b/Plant/FORAGE/for_grow.for
@@ -2430,7 +2430,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !       TF (01/16/2026) - Replaced the default ecotype handling with
 !       an error call to avoid the use of unexisting ecotype IDs.
-        CALL ERROR("IPECO",21,FILEGC,1)
+        CALL ERROR("IPECO",5,FILEGC,1)
         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
         !ECONO = 'DFAULT'
         !REWIND(LUNECO)

--- a/Plant/FORAGE/for_grow.for
+++ b/Plant/FORAGE/for_grow.for
@@ -2428,9 +2428,12 @@ C-----------------------------------------------------------------------
         EXIT
         ENDIF
         ELSE IF (ISECT .EQ. 0) THEN
-        IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-        ECONO = 'DFAULT'
-        REWIND(LUNECO)
+!       TF (01/16/2026) - Replaced the default ecotype handling with
+!       an error call to avoid the use of unexisting ecotype IDs.
+        CALL ERROR("IPECO",21,FILEGC,1)
+        !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+        !ECONO = 'DFAULT'
+        !REWIND(LUNECO)
         ENDIF
         ENDDO
   

--- a/Plant/FORAGE/for_incomp.for
+++ b/Plant/FORAGE/for_incomp.for
@@ -174,9 +174,12 @@ C-----------------------------------------------------------------------
         EXIT
         ENDIF
         ELSE IF (ISECT .EQ. 0) THEN
-        IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-        ECONO = 'DFAULT'
-        REWIND(LUNECO)
+!       TF (01/16/2026) - Replaced the default ecotype handling with
+!       an error call to avoid the use of unexisting ecotype IDs.
+        CALL ERROR("IPECO",21,FILEGC,1)
+        !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+        !ECONO = 'DFAULT'
+        !REWIND(LUNECO)
         ENDIF
       ENDDO
 

--- a/Plant/FORAGE/for_incomp.for
+++ b/Plant/FORAGE/for_incomp.for
@@ -176,7 +176,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !       TF (01/16/2026) - Replaced the default ecotype handling with
 !       an error call to avoid the use of unexisting ecotype IDs.
-        CALL ERROR("IPECO",21,FILEGC,1)
+        CALL ERROR("IPECO",5,FILEGC,1)
         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
         !ECONO = 'DFAULT'
         !REWIND(LUNECO)

--- a/Plant/FORAGE/for_pods.for
+++ b/Plant/FORAGE/for_pods.for
@@ -223,7 +223,7 @@ C-----------------------------------------------------------------------
         ELSE IF (ISECT .EQ. 0) THEN
 !       TF (01/16/2026) - Replaced the default ecotype handling with
 !       an error call to avoid the use of unexisting ecotype IDs.
-        CALL ERROR("IPECO",21,FILEGC,1)
+        CALL ERROR("IPECO",5,FILEGC,1)
         !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
         !ECONO = 'DFAULT'
         !REWIND(LUNECO)

--- a/Plant/FORAGE/for_pods.for
+++ b/Plant/FORAGE/for_pods.for
@@ -221,9 +221,12 @@ C-----------------------------------------------------------------------
         EXIT
         ENDIF
         ELSE IF (ISECT .EQ. 0) THEN
-        IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
-        ECONO = 'DFAULT'
-        REWIND(LUNECO)
+!       TF (01/16/2026) - Replaced the default ecotype handling with
+!       an error call to avoid the use of unexisting ecotype IDs.
+        CALL ERROR("IPECO",21,FILEGC,1)
+        !IF (ECONO .EQ. 'DFAULT') CALL ERROR(ERRKEY,3,FILEGC,LNUM)
+        !ECONO = 'DFAULT'
+        !REWIND(LUNECO)
         ENDIF
       ENDDO
 
@@ -1174,7 +1177,7 @@ C=======================================================================
 !             (g[N] / g[shell])
 ! FNPDT(I)  Critical values of temperature for function to reduce pod 
 !             addition and seed setting rates under non-optimal temperatures
-!             (°C)
+!             (ï¿½C)
 ! GDMSD     Seed growth demand based on temperature and photoperiod
 !             (g[seed] / m2 / d)
 ! GRRAT1    Maximum growth per individual shell (g / shell / d)
@@ -1322,7 +1325,7 @@ C=======================================================================
 !             reproductive development temperature function
 !             (photo-thermal days / day)
 ! TEMPOD    Factor for modifying pod setting based on temperature 
-! TGRO(I)   Hourly air temperature (°C)
+! TGRO(I)   Hourly air temperature (ï¿½C)
 ! THETA     Curvature of rectangular hyperbola to limit seed growth rate to 
 !             hold minimum seed N concentration. 
 ! THRESH    The maximum ratio mass of seed to mass of seed plus shell at 


### PR DESCRIPTION
Updated the source code to avoid using default ecotype genetic coefficients when the ecotype ID in cultivar file does not exist in the ecotype file.