### PR TITLE
Corrected set_real_mem_yrdoy call.

### DIFF
--- a/FlexibleIO/Interface/FInterface.f90
+++ b/FlexibleIO/Interface/FInterface.f90
@@ -633,7 +633,7 @@ contains
         varnamestr = varname
         varnamestr(LEN(varnamestr):LEN(varnamestr)) = CHAR(0)
         
-        call set_real_mem_yrdoy(groupstr, yrdoy, varname, value)
+        call set_real_mem_yrdoy(groupstr, yrdoy, varnamestr, value)
         
     end subroutine setRealYrdoyMemory
     


### PR DESCRIPTION
The subroutine was corrected to accept the properly terminated varnamestr. This was breaking attempts to update daily calculated values indexed by YEARDOY.